### PR TITLE
Improved form validation feedback

### DIFF
--- a/interface/forms.py
+++ b/interface/forms.py
@@ -29,15 +29,15 @@ class OperationalImpactForm(forms.Form):
     # Impact values
     energy_consumption = forms.FloatField(
         label="Energy consumption (in kWh)",
-        widget=forms.NumberInput(attrs={'class': 'form-control'})
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number'})
     )
     carbon_footprint = forms.FloatField(
         label="Carbon footprint (in gCO2e)",
-        widget=forms.NumberInput(attrs={'class': 'form-control'})
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number'})
     )
     water_consumption = forms.FloatField(
         label="Water consumption (in liters)",
-        widget=forms.NumberInput(attrs={'class': 'form-control'})
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number'})
     )
 
     # Methods and scope
@@ -75,7 +75,7 @@ class OperationalImpactForm(forms.Form):
     
     pue_value = forms.FloatField(
         label="Power Usage Effectiveness (PUE) Value",
-        widget=forms.NumberInput(attrs={'class': 'form-control', 'min': '1'}),
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number ≥ 1', 'min': '1'}),
         required=False
     )
     
@@ -87,7 +87,7 @@ class OperationalImpactForm(forms.Form):
     
     wue_value = forms.FloatField(
         label="Water Usage Effectiveness (WUE) Value (in L/kWh)",
-        widget=forms.NumberInput(attrs={'class': 'form-control'}),
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number'}),
         required=False
     )
     
@@ -99,7 +99,7 @@ class OperationalImpactForm(forms.Form):
     
     electrical_carbon_intensity = forms.FloatField(
         label="Electrical Carbon Intensity Value (in gCO2e/kWh)",
-        widget=forms.NumberInput(attrs={'class': 'form-control'})
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number'})
     )
     
     electrical_carbon_intensity_source = forms.CharField(
@@ -112,22 +112,22 @@ class EmbodiedImpactForm(forms.ModelForm):
         model = EmbodiedImpact
         fields = '__all__'
         widgets = {
-            'carbon_footprint': forms.NumberInput(attrs={'class': 'form-control', 'placeholder': 'gCO2e'}),
+            'carbon_footprint': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number (gCO2e)'}),
             'carbon_footprint_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'}),
-            'depletion_abiotic': forms.NumberInput(attrs={'class': 'form-control', 'placeholder': 'kg Sb-eq'}),
+            'depletion_abiotic': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number (kg Sb-eq)'}),
             'depletion_abiotic_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'}),
-            'particulate_matter': forms.NumberInput(attrs={'class': 'form-control', 'placeholder': 'disease incidence'}),
+            'particulate_matter': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number (disease incidence)'}),
             'particulate_matter_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'}),
-            'acidification_potential': forms.NumberInput(attrs={'class': 'form-control', 'placeholder': 'kg mol H+'}),
+            'acidification_potential': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number (kg mol H+)'}),
             'acidification_potential_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'}),
-            'ionising_radiation': forms.NumberInput(attrs={'class': 'form-control', 'placeholder': 'kBq U-235'}),
+            'ionising_radiation': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number (kBq U-235)'}),
             'ionising_radiation_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'}),
-            'photochemical_ozone': forms.NumberInput(attrs={'class': 'form-control', 'placeholder': 'kg NMVOC-eq'}),
+            'photochemical_ozone': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number (kg NMVOC-eq)'}),
             'photochemical_ozone_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'}),
-            'abiotic_depletion_fossil': forms.NumberInput(attrs={'class': 'form-control', 'placeholder': 'MJ'}),
+            'abiotic_depletion_fossil': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number (MJ)'}),
             'abiotic_depletion_fossil_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'}),
-            'freshwater_ecotoxicity': forms.NumberInput(attrs={'class': 'form-control', 'placeholder': 'CTUe'}),
-            'freshwater_ecotoxicity_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'}),
+            'freshwater_ecotoxicity': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Enter a number (CTUe)'}),
+            'freshwater_ecotoxicity_source': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Source and method'})
         }
 
 class BasicInformationForm(forms.ModelForm):

--- a/interface/templates/computing.html
+++ b/interface/templates/computing.html
@@ -388,16 +388,18 @@
     let debounceTimer;
 
     // Function to validate a numeric input
-    function validateNumericInput(input) {
+    function validateNumericInput(input, shouldShowError = true) {
         const value = input.value;
         const name = input.name;
         const isRequired = input.hasAttribute('required');
 
-        // Clear previous validation state
-        input.classList.remove('is-invalid');
-        const existingTooltip = input.nextElementSibling;
-        if (existingTooltip && existingTooltip.classList.contains('invalid-tooltip')) {
-            existingTooltip.remove();
+        // Clear previous validation state if we're showing errors
+        if (shouldShowError) {
+            input.classList.remove('is-invalid');
+            const existingTooltip = input.nextElementSibling;
+            if (existingTooltip && existingTooltip.classList.contains('invalid-tooltip')) {
+                existingTooltip.remove();
+            }
         }
 
         // Skip validation if field is optional and empty
@@ -407,27 +409,29 @@
 
         // Validate numeric value
         const numValue = parseFloat(value);
-        if (isNaN(numValue) || value.trim() !== String(numValue)) {
+        const isValid = !isNaN(numValue) && value.trim() === String(numValue);
+
+        // Additional validation for specific fields
+        if (isValid && name.includes('pue_value') && numValue < 1) {
+            if (shouldShowError) {
+                input.classList.add('is-invalid');
+                const tooltip = document.createElement('div');
+                tooltip.className = 'invalid-tooltip';
+                tooltip.textContent = 'PUE value must be greater than or equal to 1';
+                input.parentNode.insertBefore(tooltip, input.nextSibling);
+            }
+            return false;
+        }
+
+        if (!isValid && shouldShowError) {
             input.classList.add('is-invalid');
             const tooltip = document.createElement('div');
             tooltip.className = 'invalid-tooltip';
             tooltip.textContent = 'Please enter a valid number';
             input.parentNode.insertBefore(tooltip, input.nextSibling);
-            return false;
         }
 
-        // Additional validation for specific fields
-        if (name.includes('pue_value') && numValue < 1) {
-            input.classList.add('is-invalid');
-            const tooltip = document.createElement('div');
-            tooltip.className = 'invalid-tooltip';
-            tooltip.textContent = 'PUE value must be greater than or equal to 1';
-            input.parentNode.insertBefore(tooltip, input.nextSibling);
-            return false;
-        }
-
-        // All validations passed
-        return true;
+        return isValid;
     }
 
     // Function to update preview with debounce
@@ -495,7 +499,8 @@
                     input.placeholder.toLowerCase().includes('number');
 
                 if (isNumericField) {
-                    if (validateNumericInput(input)) {
+                    // Only validate the value, don't show errors during data collection
+                    if (validateNumericInput(input, false)) {
                         formData[cleanName] = value;
                     }
                 } else {
@@ -512,11 +517,14 @@
         const form = document.getElementById(formId);
         if (!form) return;
 
-        // Initial form data collection
+        // Initial form data collection without showing validation errors
         collectFormData(form);
 
         // Add event listeners
         form.querySelectorAll('input, textarea, select').forEach(input => {
+            // Add a flag to track if the field has been interacted with
+            input.dataset.touched = 'false';
+
             if (input.type === 'checkbox') {
                 input.addEventListener('change', () => {
                     collectFormData(form);
@@ -529,11 +537,13 @@
 
                 if (isNumericField) {
                     input.addEventListener('input', () => {
-                        validateNumericInput(input);
+                        input.dataset.touched = 'true';
+                        validateNumericInput(input, true);
                         collectFormData(form);
                     });
                     input.addEventListener('blur', () => {
-                        validateNumericInput(input);
+                        input.dataset.touched = 'true';
+                        validateNumericInput(input, true);
                     });
                 } else {
                     input.addEventListener('input', () => {

--- a/interface/templates/computing.html
+++ b/interface/templates/computing.html
@@ -5,6 +5,35 @@
     document.body.classList.add('has-progress-sidebar');
 </script>
 
+<style>
+    .form-control.is-invalid {
+        border-color: #dc3545;
+        padding-right: calc(1.5em + 0.75rem);
+        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
+        background-repeat: no-repeat;
+        background-position: right calc(0.375em + 0.1875rem) center;
+        background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+    }
+
+    .invalid-tooltip {
+        display: none;
+        position: absolute;
+        top: 100%;
+        z-index: 5;
+        max-width: 100%;
+        padding: 0.25rem 0.5rem;
+        margin-top: 0.1rem;
+        font-size: 0.875rem;
+        color: #fff;
+        background-color: rgba(220, 53, 69, 0.9);
+        border-radius: 0.25rem;
+    }
+
+    .form-control.is-invalid~.invalid-tooltip {
+        display: block;
+    }
+</style>
+
 <div class="container-fluid">
     <div class="row">
         <div class="col-md-8">
@@ -354,53 +383,52 @@
 </div>
 
 {% block extra_js %}
-<style>
-    .list-unstyled {
-        padding-left: 0;
-        list-style: none;
-    }
-
-    .list-unstyled li {
-        margin-bottom: 0.5rem;
-    }
-
-    .card-header {
-        background-color: #f8f9fa;
-        border-bottom: 1px solid rgba(0, 0, 0, .125);
-    }
-
-    .card-header h5,
-    .card-header h6 {
-        margin-bottom: 0;
-        color: #2c3e50;
-    }
-
-    .btn-group {
-        gap: 0.5rem;
-    }
-
-    #yml-preview::-webkit-scrollbar {
-        width: 8px;
-    }
-
-    #yml-preview::-webkit-scrollbar-track {
-        background: #2a2e32;
-        border-radius: 4px;
-    }
-
-    #yml-preview::-webkit-scrollbar-thumb {
-        background: #454b52;
-        border-radius: 4px;
-    }
-
-    #yml-preview::-webkit-scrollbar-thumb:hover {
-        background: #515961;
-    }
-</style>
-
 <script>
     let formData = {};
     let debounceTimer;
+
+    // Function to validate a numeric input
+    function validateNumericInput(input) {
+        const value = input.value;
+        const name = input.name;
+        const isRequired = input.hasAttribute('required');
+
+        // Clear previous validation state
+        input.classList.remove('is-invalid');
+        const existingTooltip = input.nextElementSibling;
+        if (existingTooltip && existingTooltip.classList.contains('invalid-tooltip')) {
+            existingTooltip.remove();
+        }
+
+        // Skip validation if field is optional and empty
+        if (!isRequired && (!value || value.trim() === '')) {
+            return true;
+        }
+
+        // Validate numeric value
+        const numValue = parseFloat(value);
+        if (isNaN(numValue) || value.trim() !== String(numValue)) {
+            input.classList.add('is-invalid');
+            const tooltip = document.createElement('div');
+            tooltip.className = 'invalid-tooltip';
+            tooltip.textContent = 'Please enter a valid number';
+            input.parentNode.insertBefore(tooltip, input.nextSibling);
+            return false;
+        }
+
+        // Additional validation for specific fields
+        if (name.includes('pue_value') && numValue < 1) {
+            input.classList.add('is-invalid');
+            const tooltip = document.createElement('div');
+            tooltip.className = 'invalid-tooltip';
+            tooltip.textContent = 'PUE value must be greater than or equal to 1';
+            input.parentNode.insertBefore(tooltip, input.nextSibling);
+            return false;
+        }
+
+        // All validations passed
+        return true;
+    }
 
     // Function to update preview with debounce
     function updatePreview() {
@@ -461,7 +489,18 @@
             const value = input.value;
             if (name) {
                 const cleanName = name.replace('embodied-', '').replace('operational-', '');
-                formData[cleanName] = value;
+                // Check if this is a numeric field (based on FloatField in Django form)
+                const isNumericField = input.classList.contains('form-control') &&
+                    input.placeholder &&
+                    input.placeholder.toLowerCase().includes('number');
+
+                if (isNumericField) {
+                    if (validateNumericInput(input)) {
+                        formData[cleanName] = value;
+                    }
+                } else {
+                    formData[cleanName] = value;
+                }
             }
         });
 
@@ -483,9 +522,24 @@
                     collectFormData(form);
                 });
             } else {
-                input.addEventListener('input', () => {
-                    collectFormData(form);
-                });
+                // For numeric fields, validate on input and blur
+                const isNumericField = input.classList.contains('form-control') &&
+                    input.placeholder &&
+                    input.placeholder.toLowerCase().includes('number');
+
+                if (isNumericField) {
+                    input.addEventListener('input', () => {
+                        validateNumericInput(input);
+                        collectFormData(form);
+                    });
+                    input.addEventListener('blur', () => {
+                        validateNumericInput(input);
+                    });
+                } else {
+                    input.addEventListener('input', () => {
+                        collectFormData(form);
+                    });
+                }
             }
         });
     });


### PR DESCRIPTION
### **PR Description**

**Summary:**
This PR enhances the user experience of numeric input validation within the Live Preview interface by moving from restricted input types to more flexible, user-friendly validation and feedback mechanisms.

---

**Changes Made:**

* Replaced all `input type="number"` fields with `type="text"` to allow unrestricted typing.
* Implemented client-side validation that:

  * Triggers on both `input` and `blur` events
  * Provides immediate visual feedback via red borders
  * Displays helpful tooltips explaining the error
* Prevented invalid numeric values from propagating to the YAML preview
* Added more descriptive placeholders (e.g., including expected units and format hints)

---

**Why This Matters:**

As suggested, server-side validation within the `if request.method == 'POST':` block was not being triggered due to the Live Preview architecture. As a result, users received no feedback when entering invalid numeric values — despite those values being excluded from the final YAML.

---

**Next Steps:**

Currently, the validation only checks whether the value is a valid number. Since I do not yet have clarity on the **specific numeric constraints** (e.g. expected ranges), I have not enforced any range validation.

It might be helpful to have a quick meeting with the domain experts to align on:

* Valid input ranges for each numeric field
* Any units conversions or normalization steps needed
* Additional validation logic to be added going forward